### PR TITLE
Traverse style chain instead of taking the first style name directly

### DIFF
--- a/src/docx2jats/objectModel/Document.php
+++ b/src/docx2jats/objectModel/Document.php
@@ -177,6 +177,33 @@ class Document {
 		}
 	}
 
+	static function getBuiltinStyle(string $constStyleType, string $id, array $builtinStyles): ?string {
+		// Traverse the chain of styles to see if the named id style
+		// inherits from one of the sought-for built-in styles and
+		// return the one that matches.
+		if (self::$stylesXpath) {
+			do {
+				$element = self::$stylesXpath->query("/w:styles/w:style[@w:type='" . $constStyleType . "'][@w:styleId='" . $id . "']")[0];
+
+				$basedOn = self::$stylesXpath->query("w:basedOn", $element)[0];
+				$id = $basedOn ? $basedOn->getAttribute("w:val") : null;
+
+				$name = self::$stylesXpath->query("w:name", $element)[0];
+				$styleName = $name->getAttribute("w:val");
+
+				if (in_array($styleName, $builtinStyles)) return $styleName;
+			} while($id);
+
+			return null;
+		} else {
+
+			// Fall back on using the original id as if it were the name
+			if (in_array($id, $builtinStyles)) return $id;
+			else return null;
+		}
+	}
+
+
 	private function isDrawing($childNode): bool {
 		$element = Document::$xpath->query("w:r//w:drawing", $childNode)[0];
 		if ($element) return true;

--- a/src/docx2jats/objectModel/body/Par.php
+++ b/src/docx2jats/objectModel/body/Par.php
@@ -112,20 +112,10 @@ class Par extends DataObject {
 	private function defineType() {
 		$type = array();
 		$styles = $this->getXpath()->query('w:pPr/w:pStyle/@w:val', $this->getDomElement());
-		if ($this->isOnlyChildNode($styles)) {
+		if ($this->isOnlyChildNode($styles) &&
+			Document::getBuiltinStyle(Document::DOCX_STYLES_PARAGRAPH, $styles[0]->nodeValue, self::$headings)) {
 
-			// Find associated style in style.xml; TODO explore consistency for different languages
-			$associatedStyle = Document::getElementStyling(Document::DOCX_STYLES_PARAGRAPH, $styles[0]->nodeValue);
-
-			// Fallback to the node content if styles.xml doesn't exist
-			if (!$associatedStyle) {
-				$associatedStyle = $styles[0]->nodeValue;
-			}
-
-			if (in_array(strtolower($associatedStyle), self::$headings)) {
-				$type[] = self::DOCX_PAR_HEADING;
-			}
-
+			$type[] = self::DOCX_PAR_HEADING;
 		}
 
 		//w:numPr node can appear in lists, heading (heading level), text corrections -> with a child ins with the name of the editor, etc...
@@ -155,9 +145,7 @@ class Par extends DataObject {
 		$styleString = '';
 		if (in_array(self::DOCX_PAR_HEADING, $this->type )) {
 			$styles = $this->getXpath()->query('w:pPr/w:pStyle/@w:val', $this->getDomElement());
-			if ($this->isOnlyChildNode($styles)) {
-				$styleString = $styles[0]->nodeValue;
-			}
+			$styleString = Document::getBuiltinStyle(Document::DOCX_STYLES_PARAGRAPH, $styles[0]->nodeValue, self::$headings);
 		}
 
 		// Not a heading if empty


### PR DESCRIPTION
Users can define their own styles, which may inherit from built-in
styles.  This results in a style chain (the built-in headings also
inherit from the "standard" style, for example).  To find if a style
is a heading, we must traverse this chain (see also L.1.8.9 Style Inheritance in ECMA-376) .

In this commit, I've also removed the comment about figuring out if languages use the same builtins. It appears Dutch Word versions also use the English names like "heading 2" as builtin. Strangely, its parent style is called "Standaard", which is Dutch again.